### PR TITLE
fix(ci): use original flake8 rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         id: lint
         run: |
           flake8 *.py --max-line-length=120 --count --show-source --statistics \
-            --select=E9,F63,F7,F82,E1,E4,W6
+            --select=E9,F63,F7,F82
 
       - name: Verify imports
         id: imports


### PR DESCRIPTION
Reverts expanded E1/E4/W6 rules that caught pre-existing style issues.