### PR TITLE
fix: route downloads through gaia secured playlist

### DIFF
--- a/tldv_downloader.py
+++ b/tldv_downloader.py
@@ -6,12 +6,16 @@ Enhanced version with better error handling, filename sanitization, and N_m3u8DL
 
 import re
 import json
+import tempfile
 import requests
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
+
+GAIA_BASE = "https://gaia.tldv.io"
+GW_BASE = "https://gw.tldv.io"
 
 
 class TLDVDownloader:
@@ -55,7 +59,7 @@ class TLDVDownloader:
 
     def fetch_meeting_data(self, meeting_id, auth_token):
         """Fetch meeting data from TLDV API"""
-        api_url = f"https://gw.tldv.io/v1/meetings/{meeting_id}/watch-page?noTranscript=true"
+        api_url = f"{GW_BASE}/v1/meetings/{meeting_id}/watch-page?noTranscript=true"
 
         headers = {
             "Authorization": auth_token,
@@ -77,6 +81,69 @@ class TLDVDownloader:
         except requests.exceptions.RequestException as e:
             raise ValueError(f"Network error: {e}") from e
 
+    @staticmethod
+    def _caesar_shift(text, shift):
+        """Apply caesar shift on letters; digits/punctuation untouched."""
+        out = []
+        for ch in text:
+            if 'a' <= ch <= 'z':
+                out.append(chr((ord(ch) - ord('a') + shift) % 26 + ord('a')))
+            elif 'A' <= ch <= 'Z':
+                out.append(chr((ord(ch) - ord('A') + shift) % 26 + ord('A')))
+            else:
+                out.append(ch)
+        return ''.join(out)
+
+    def fetch_decoded_playlist(self, meeting_id, auth_token):
+        """Fetch the signed HLS playlist from gaia and decode obfuscated segment URLs.
+
+        Flow:
+          GET gaia.tldv.io/v1/meetings/{id}/playlist.m3u8 -> 302 puttanesca proxy ->
+          media playlist with #TLDVCONF:<expires>,<shift>,<prefix> header and
+          caesar-shifted segment filenames. Decode back to absolute signed S3 URLs.
+        """
+        api_url = f"{GAIA_BASE}/v1/meetings/{meeting_id}/playlist.m3u8"
+        headers = {"Authorization": auth_token, "Accept": "application/vnd.apple.mpegurl"}
+        try:
+            response = self.session.get(api_url, headers=headers, timeout=30, allow_redirects=True)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            code = getattr(e.response, "status_code", None)
+            if code == 401:
+                raise ValueError("Unauthorized: Invalid auth token") from e
+            if code == 403:
+                raise ValueError("Forbidden: insufficient permission for this meeting") from e
+            if code == 404:
+                raise ValueError("Meeting playlist not found") from e
+            raise ValueError(f"Playlist API error: {e}") from e
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"Network error fetching playlist: {e}") from e
+
+        raw = response.text
+        prefix = ""
+        shift = 0
+        out_lines = ["#EXTM3U"]
+        for line in raw.splitlines():
+            if line.startswith("#TLDVCONF:"):
+                parts = line[len("#TLDVCONF:"):].split(",", 2)
+                if len(parts) >= 3:
+                    try:
+                        shift = int(parts[1])
+                    except ValueError:
+                        shift = 0
+                    prefix = parts[2]
+                continue
+            if line.startswith("#EXTM3U"):
+                continue
+            if line.startswith("#") or not line.strip():
+                out_lines.append(line)
+            else:
+                out_lines.append(prefix + self._caesar_shift(line, shift))
+
+        if not prefix:
+            raise ValueError("Playlist did not contain #TLDVCONF header; format may have changed")
+        return "\n".join(out_lines) + "\n"
+
     def parse_meeting_info(self, data):
         """Parse meeting information from API response"""
         meeting = data.get("meeting", {})
@@ -84,10 +151,7 @@ class TLDVDownloader:
 
         name = meeting.get("name", "TLDV_Meeting")
         created_at = meeting.get("createdAt")
-        source_url = video.get("source")
-
-        if not source_url:
-            raise ValueError("Video source URL not found in meeting data")
+        source_url = video.get("source")  # informational only; unsigned, not used for download
 
         # Parse date
         try:
@@ -140,31 +204,32 @@ class TLDVDownloader:
         preferred = next((d for d in available if d['preferred']), available[0])
         return preferred
 
-    def download_with_n_m3u8dl_re(self, source_url, output_file):
-        """Download using N_m3u8DL-RE"""
+    def download_with_n_m3u8dl_re(self, playlist_path, output_file):
+        """Download using N_m3u8DL-RE from a local decoded playlist file."""
         command = [
             'N_m3u8DL-RE',
-            source_url,
+            str(playlist_path),
             '--save-name', Path(output_file).stem,
             '--save-dir', str(Path(output_file).parent),
-            '--thread-count', '8',  # Parallel downloads
+            '--thread-count', '8',
             '--download-retry-count', '3',
-            '--auto-select',  # Auto select best quality
-            '--no-log'  # Reduce log verbosity
+            '--auto-select',
+            '--no-log',
         ]
-
         return self._run_download_command(command, output_file)
 
-    def download_with_ffmpeg(self, source_url, output_file):
-        """Download using ffmpeg"""
+    def download_with_ffmpeg(self, playlist_path, output_file):
+        """Download using ffmpeg from a local decoded playlist file."""
         command = [
             'ffmpeg',
-            '-i', source_url,
+            '-protocol_whitelist', 'file,http,https,tcp,tls',
+            '-allowed_extensions', 'ALL',
+            '-i', str(playlist_path),
             '-c', 'copy',
-            '-y',  # Overwrite output file
-            str(output_file)
+            '-bsf:a', 'aac_adtstoasc',
+            '-y',
+            str(output_file),
         ]
-
         return self._run_download_command(command, output_file)
 
     def _run_download_command(self, command, output_file):
@@ -321,11 +386,26 @@ class TLDVDownloader:
             metadata_name = f"{info['timestamp']}_{info['name']}"
             self.save_metadata(info['full_data'], output_path / metadata_name)
 
-            # Download video
-            if downloader['name'] == 'N_m3u8DL-RE':
-                success = self.download_with_n_m3u8dl_re(info['source_url'], output_file)
-            else:
-                success = self.download_with_ffmpeg(info['source_url'], output_file)
+            # Fetch and decode the secured HLS playlist
+            print("🔓 Fetching secured playlist...")
+            decoded_playlist = self.fetch_decoded_playlist(meeting_id, auth_token)
+
+            with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.m3u8', delete=False, encoding='utf-8'
+            ) as tmp:
+                tmp.write(decoded_playlist)
+                playlist_path = Path(tmp.name)
+
+            try:
+                if downloader['name'] == 'N_m3u8DL-RE':
+                    success = self.download_with_n_m3u8dl_re(playlist_path, output_file)
+                else:
+                    success = self.download_with_ffmpeg(playlist_path, output_file)
+            finally:
+                try:
+                    playlist_path.unlink()
+                except OSError:
+                    pass
 
             if success:
                 print(f"\n🎉 Successfully downloaded: {output_file}")


### PR DESCRIPTION
## Summary

Both existing download paths in `tldv_downloader.py` are broken against the current tldv.io backend:

1. **Legacy `GET gw.tldv.io/v1/meetings/{id}/download`** returns a signed URL pointing at the S3 bucket `streaming-source-5ps85qawff1p`, which no longer exists (`NoSuchBucket`).
2. **HLS fallback via `watch-page.video.source`** returns a raw `https://media-files.tldv.io/.../master.m3u8` URL with no signing params. Wasabi answers `403 AccessDenied` for every request variant (no auth, Bearer, referer, token cookie, etc.), because the object requires an AWS SigV4 query string.

Net effect: the script reliably reaches the \"download failed return code 8\" branch on any live meeting today.

## Fix

Reverse-engineered the web player and switched to the same pipeline it uses:

1. `GET gaia.tldv.io/v1/meetings/{id}/playlist.m3u8` with the Bearer token.
2. Follow the 302 to `puttanesca-v0.tldv.io/v1/playlist.m3u8?t=<JWT>` (playlist JWT, ~48 h TTL).
3. Parse the custom `#TLDVCONF:<expiresSeconds>,<caesarShift>,<mediaBasePrefix>` header.
4. For each segment line, apply the advertised Caesar shift to restore the real AWS SigV4 query string (`X-Amz-Algorithm`, `X-Amz-Signature`, etc.) and prepend `<mediaBasePrefix>` to recover the absolute `media-files.tldv.io/...` URL.
5. Write the fully rewritten playlist to a tempfile and feed it to `N_m3u8DL-RE` (if available) or `ffmpeg` (now invoked with `-protocol_whitelist file,http,https,tcp,tls`, `-allowed_extensions ALL`, and `-bsf:a aac_adtstoasc`).

`video.source` is still surfaced in metadata for context but is no longer required for the download.

## Changes

`tldv_downloader.py` (+103 / -23):

- Added `GAIA_BASE` / `GW_BASE` constants.
- Added `_caesar_shift(text, shift)` static helper.
- Added `fetch_decoded_playlist(meeting_id, auth_token)` that performs the gaia call, follows the redirect, and returns a ready-to-use m3u8 string with absolute signed segment URLs.
- `download_with_n_m3u8dl_re` / `download_with_ffmpeg` now accept a local playlist path (ffmpeg gained the protocol whitelist + `aac_adtstoasc` bitstream filter).
- `download_video` writes the decoded playlist to `tempfile.NamedTemporaryFile(suffix='.m3u8')`, passes the path to the chosen downloader, and unlinks on completion.
- `parse_meeting_info` no longer raises when `video.source` is missing, since the unsigned URL is not required anymore.

## Test plan

- [x] Python `py_compile` passes.
- [x] Unit-tested Caesar decoder: `_caesar_shift('L-Oan-Ozucfwhva', 12) == 'X-Amz-Algorithm'`.
- [x] Live playlist fetch against a real meeting returns a valid, non-obfuscated m3u8 (~1.1 MB, ~2268 two-second segments for a 1h15m recording).
- [x] `HTTP GET` on the first decoded segment returns `200` with binary TS payload.
- [x] Full end-to-end download: 1h15m35s meeting -> 289 MB MP4 muxed by ffmpeg, ~5x realtime speed.
- [ ] Retest with N_m3u8DL-RE (not installed on the dev machine; the path is wired up and receives the same local playlist input).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented improved video download mechanism with enhanced playlist processing and decoding.

* **Bug Fixes**
  * Expanded error handling for connection failures during video retrieval with explicit categorization of different failure scenarios, providing clearer diagnostics for download issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->