### PR TITLE
ci(cosign): canonical signing workflow per ADR-041

### DIFF
--- a/.github/workflows/cosign-sign-image.yml
+++ b/.github/workflows/cosign-sign-image.yml
@@ -1,0 +1,102 @@
+# Cosign image-signing workflow template — copy to <repo>/.github/workflows/cosign.yml
+# Per ADR-041 (Trivy + Cosign deploy gate). Sample distribution scope: 18 app repos.
+#
+# Required GitHub secrets (pull from Infisical-CI MI):
+#   COSIGN_PRIVATE_KEY  — base64-encoded private key
+#   COSIGN_PASSWORD     — passphrase for private key
+#   GHCR_PAT            — GitHub PAT with write:packages (or use built-in GITHUB_TOKEN if same org)
+#
+# Public key for verification: published at https://gist.githubusercontent.com/Cramraika/c246bdb779518a588617839bfe2a75c1/raw/cosign.pub
+# Coolify pre-deploy hook (vps_host/scripts/coolify-hooks/trivy-pre-deploy.sh):
+#   - Pulls image
+#   - Runs Trivy CVE scan
+#   - cosign verify --key <pub-key-url> <image>
+#   - Refuses deploy on either Trivy CRITICAL or cosign verify fail
+
+name: Cosign image signing
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write  # for keyless via OIDC if desired (alternate path)
+
+jobs:
+  build-sign-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with key
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for tag in $(echo "${{ steps.meta.outputs.tags }}" | tr ',' ' '); do
+            echo "Signing $tag@${{ steps.build.outputs.digest }}"
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY \
+              "$tag@${{ steps.build.outputs.digest }}"
+          done
+
+      - name: Generate SBOM (syft)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attach SBOM to image
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          cosign attest --yes --key env://COSIGN_PRIVATE_KEY \
+            --predicate sbom.spdx.json --type spdxjson \
+            "ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"
+
+      - name: Verify signature (smoke test)
+        run: |
+          cosign verify \
+            --key https://gist.githubusercontent.com/Cramraika/c246bdb779518a588617839bfe2a75c1/raw/cosign.pub \
+            "ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
## Summary

Adds canonical Cosign image-signing workflow per ADR-041 (Trivy + Cosign deploy gate). Distributed via PCN Session 14 Track 14-J Pattern 1 fanout from PR #50 on host_page (squash 11db81c).

## Mechanism

- Triggers on push to main + tag pushes (v*) + workflow_dispatch
- Builds + pushes image to GHCR via existing GITHUB_TOKEN
- Signs image with Cosign keypair (Infisical /cosign/ in backups workspace)
- Generates SPDX SBOM and attaches as cosign attestation
- Smoke-test verifies signature against published public key

## Required secrets (already populated)

- COSIGN_PRIVATE_KEY (set via gh secret set, sourced from Infisical)
- COSIGN_PASSWORD (set via gh secret set, sourced from Infisical)

## Public verification key

https://gist.githubusercontent.com/Cramraika/c246bdb779518a588617839bfe2a75c1/raw/cosign.pub

## Refs

- ADR-041: Trivy + Cosign deploy gate
- platform-docs/docs/audits/cosign-distribute-19-repos-20260427.md
- host_page PR #50 (canonical template)
